### PR TITLE
refactor(gh): perfume events display

### DIFF
--- a/src/main/kotlin/io/github/starwishsama/comet/api/thirdparty/github/data/events/IssueCommentEvent.kt
+++ b/src/main/kotlin/io/github/starwishsama/comet/api/thirdparty/github/data/events/IssueCommentEvent.kt
@@ -38,13 +38,13 @@ data class IssueCommentEvent(
         fun convertCreatedTime(): String {
             val localTime =
                 LocalDateTime.parse(createdTime, DateTimeFormatter.ISO_OFFSET_DATE_TIME).atZone(ZoneId.systemDefault())
-            return CometVariables.yyMMddPattern.format(localTime)
+            return CometVariables.hmsPattern.format(localTime)
         }
     }
 
     override fun toMessageWrapper(): MessageWrapper {
         return MessageWrapper().apply {
-            addText("\uD83D\uDCAC 仓库 ${repository.fullName} 议题 #${issue.number} 下有新回复\n")
+            addText("\uD83D\uDCAC ${repository.fullName} 议题 #${issue.number} 下有新回复\n")
             addText("| 创建时间 ${comment.convertCreatedTime()}\n")
             addText("| 创建人 ${comment.user.login}\n")
             addText("| 查看详细信息: ${comment.url}\n")

--- a/src/main/kotlin/io/github/starwishsama/comet/api/thirdparty/github/data/events/IssueEvent.kt
+++ b/src/main/kotlin/io/github/starwishsama/comet/api/thirdparty/github/data/events/IssueEvent.kt
@@ -44,7 +44,7 @@ data class IssueEvent(
         fun convertCreatedTime(): String {
             val localTime =
                 LocalDateTime.parse(createdTime, DateTimeFormatter.ISO_OFFSET_DATE_TIME).atZone(ZoneId.systemDefault())
-            return CometVariables.yyMMddPattern.format(localTime)
+            return CometVariables.hmsPattern.format(localTime)
         }
     }
 
@@ -78,19 +78,18 @@ data class IssueEvent(
 
         when (action) {
             "opened" -> {
-                wrapper.addText("\uD83D\uDC1B 仓库 ${repository.fullName} 有新议题啦\n")
+                wrapper.addText("\uD83D\uDC1B ${repository.fullName} 有新议题啦\n")
                 wrapper.addText("| 议题 #${issue.number}\n")
                 wrapper.addText("| 创建时间 ${issue.convertCreatedTime()}\n")
                 wrapper.addText("| 创建人 ${sender.login}\n")
                 wrapper.addText("| 查看详细信息: ${issue.url}\n")
-                wrapper.addText("| 简略信息: \n")
+                wrapper.addText("| 简略信息 \n")
                 wrapper.addText("| ${issue.title}\n")
                 wrapper.addText("| ${issue.body.limitStringSize(50).trim()}\n")
             }
 
             "closed" -> {
-                wrapper.addText("\uD83D\uDC1B 仓库 ${repository.fullName}\n")
-                wrapper.addText("| 议题 #${issue.number} 已关闭\n")
+                wrapper.addText("\uD83D\uDC1B ${repository.fullName} 议题 #${issue.number} 关闭\n")
                 wrapper.addText("| 创建人 ${sender.login}\n")
                 wrapper.addText("| 查看详细信息: ${issue.url}\n")
             }

--- a/src/main/kotlin/io/github/starwishsama/comet/api/thirdparty/github/data/events/PullRequestEvent.kt
+++ b/src/main/kotlin/io/github/starwishsama/comet/api/thirdparty/github/data/events/PullRequestEvent.kt
@@ -55,18 +55,18 @@ data class PullRequestEvent(
         fun convertCreatedTime(): String {
             val localTime =
                 LocalDateTime.parse(createdTime, DateTimeFormatter.ISO_OFFSET_DATE_TIME).atZone(ZoneId.systemDefault())
-            return CometVariables.yyMMddPattern.format(localTime)
+            return CometVariables.hmsPattern.format(localTime)
         }
     }
 
     override fun toMessageWrapper(): MessageWrapper {
         val wrapper = MessageWrapper()
 
-        wrapper.addText("\uD83D\uDD27 仓库 ${repository.fullName} 有新的提交更改\n")
+        wrapper.addText("\uD83D\uDD27 ${repository.fullName} 有新的提交更改\n")
         wrapper.addText("| ${pullRequestInfo.body}\n")
         wrapper.addText("| 发布时间 ${pullRequestInfo.convertCreatedTime()}\n")
         wrapper.addText("| 发布人 ${sender.login}\n")
-        wrapper.addText("| 提交更改信息: \n")
+        wrapper.addText("| 提交更改信息 \n")
         wrapper.addText("| ${pullRequestInfo.title.limitStringSize(50)}\n")
         wrapper.addText("| ${pullRequestInfo.body.limitStringSize(100).trim()}\n")
         wrapper.addText("| 查看完整信息: ${pullRequestInfo.url}")

--- a/src/main/kotlin/io/github/starwishsama/comet/api/thirdparty/github/data/events/PushEvent.kt
+++ b/src/main/kotlin/io/github/starwishsama/comet/api/thirdparty/github/data/events/PushEvent.kt
@@ -72,7 +72,7 @@ data class PushEvent(
     }
 
     private fun getLocalTime(time: Long): String {
-        return CometVariables.yyMMddPattern.format(
+        return CometVariables.hmsPattern.format(
             Instant.ofEpochMilli(time * 1000L).atZone(ZoneId.systemDefault()).toLocalDateTime()
         )
     }
@@ -80,13 +80,13 @@ data class PushEvent(
     override fun toMessageWrapper(): MessageWrapper {
         val wrapper = MessageWrapper()
 
-        wrapper.addText("⬆️ 仓库 ${repoInfo.fullName} 有新提交啦\n")
+        wrapper.addText("⬆️${repoInfo.fullName} 有新提交啦\n")
         wrapper.addText("| 推送时间 ${getLocalTime(repoInfo.pushTime)}\n")
         wrapper.addText("| 推送分支 ${ref.replace("refs/heads/", "")}\n")
         wrapper.addText("| 提交者 ${headCommitInfo.committer.name}\n")
         wrapper.addText("| 提交信息 \n")
         wrapper.addText("| ${headCommitInfo.message}\n")
-        wrapper.addText("| 查看差异: \n")
+        wrapper.addText("| 查看差异 \n")
         wrapper.addText(compare)
 
         return wrapper

--- a/src/main/kotlin/io/github/starwishsama/comet/api/thirdparty/github/data/events/ReleaseEvent.kt
+++ b/src/main/kotlin/io/github/starwishsama/comet/api/thirdparty/github/data/events/ReleaseEvent.kt
@@ -43,18 +43,18 @@ data class ReleaseEvent(
         fun convertCreatedTime(): String {
             val localTime =
                 LocalDateTime.parse(createdTime, DateTimeFormatter.ISO_OFFSET_DATE_TIME).atZone(ZoneId.systemDefault())
-            return CometVariables.yyMMddPattern.format(localTime)
+            return CometVariables.hmsPattern.format(localTime)
         }
     }
 
     override fun toMessageWrapper(): MessageWrapper {
         val wrapper = MessageWrapper()
 
-        wrapper.addText("\uD83D\uDCE6 仓库 ${repository.fullName} 有新版本发布\n")
+        wrapper.addText("\uD83D\uDCE6 ${repository.fullName} 有新版本发布\n")
         wrapper.addText("| 版本 #${release.tagName}\n")
         wrapper.addText("| 发布时间 ${release.convertCreatedTime()}\n")
         wrapper.addText("| 发布人 ${release.author.login}\n")
-        wrapper.addText("| 发布版信息: \n")
+        wrapper.addText("| 发布版信息 \n")
         wrapper.addText("| ${release.title}\n")
         wrapper.addText("| ${release.body.limitStringSize(50).trim()}\n")
         wrapper.addText("| 查看完整信息: ${release.url}")


### PR DESCRIPTION
### 更改理由

#### 对于时间格式更改

事实上，时间往往在阅读中被忽略。本次提交更改意在减少时间文本长度，其中日期等信息被隐去。但您仍可以在消息记录（QQ）中根据上下文时间以判断具体日期。况事件时效性强，而日期信息则有所多余。

#### 对于删除 `仓库` 二字

事件消息头部内容固定，在阅读时无需特别指出后面的内容是仓库名，故舍去。

#### 对于删除 `: `

考虑到换行问题，存在换行时 `: ` 似乎不再担当同一行内句读的作用，故删去。