### PR TITLE
♻️ refactor: shorter tweets

### DIFF
--- a/src/main/kotlin/io/github/starwishsama/comet/CometVariables.kt
+++ b/src/main/kotlin/io/github/starwishsama/comet/CometVariables.kt
@@ -151,6 +151,10 @@ object CometVariables {
     @Volatile
     internal var switch: Boolean = true
 
+    internal val hmPattern: DateTimeFormatter by lazy {
+        DateTimeFormatter.ofPattern("HH:mm").withZone(ZoneId.systemDefault())
+    }
+
     internal val hmsPattern: DateTimeFormatter by lazy {
         DateTimeFormatter.ofPattern("HH:mm:ss").withZone(ZoneId.systemDefault())
     }

--- a/src/main/kotlin/io/github/starwishsama/comet/api/thirdparty/twitter/data/Tweet.kt
+++ b/src/main/kotlin/io/github/starwishsama/comet/api/thirdparty/twitter/data/Tweet.kt
@@ -70,14 +70,13 @@ data class Tweet(
         val duration =
             Duration.between(getSentTime(), LocalDateTime.now())
         val extraText =
-            "❤${likeCount?.getBetterNumber()} | \uD83D\uDD01${retweetCount} | 🕘${hmsPattern.format(getSentTime())}"
+            "❤${likeCount?.getBetterNumber()} | \uD83D\uDD01${retweetCount} | 🕘${hmPattern.format(getSentTime())} - ${duration.toKotlinDuration().toFriendly(msMode = false)} 前"
 
         if (retweetStatus != null) {
             return "♻ 转推自 ${retweetStatus.user.name}:\n" +
                     "${retweetStatus.text.cleanShortUrl().limitStringSize(50)}\n" +
                     "$extraText\n" +
-                    "\uD83D\uDD17 > ${getTweetURL()}\n" +
-                    "\uD83D\uDD52 ${duration.toKotlinDuration().toFriendly(msMode = false)} 前"
+                    "\uD83D\uDD17 > ${getTweetURL()}\n"
         }
 
         if (isQuoted && quotedStatus != null) {
@@ -87,7 +86,6 @@ data class Tweet(
                 append("💬 ${quotedStatus.user.name} >\n")
                 append(quotedStatus.text.cleanShortUrl().limitStringSize(50) + "\n")
                 append("$extraText\n🔗 > ${getTweetURL()}\n")
-                append("\uD83D\uDD52 ${duration.toKotlinDuration().toFriendly(msMode = false)} 前")
             }
         }
 
@@ -100,14 +98,12 @@ data class Tweet(
                 append("\uD83D\uDCAC ${repliedTweet?.user?.name}\n")
                 append("${repliedTweet?.text?.cleanShortUrl()?.limitStringSize(50)}")
                 append("$extraText\n🔗 > ${getTweetURL()}\n")
-                append("\uD83D\uDD52 ${duration.toKotlinDuration().toFriendly(msMode = false)} 前")
             }
         }
 
         return "${text.cleanShortUrl()}\n" +
                 "$extraText\n" +
-                "🔗 > ${getTweetURL()}\n" +
-                "\uD83D\uDD52 ${duration.toKotlinDuration().toFriendly(msMode = false)} 前"
+                "🔗 > ${getTweetURL()}\n"
     }
 
     /**

--- a/src/main/kotlin/io/github/starwishsama/comet/api/thirdparty/twitter/data/Tweet.kt
+++ b/src/main/kotlin/io/github/starwishsama/comet/api/thirdparty/twitter/data/Tweet.kt
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.JsonNode
 import io.github.starwishsama.comet.CometVariables
 import io.github.starwishsama.comet.CometVariables.hmsPattern
+import io.github.starwishsama.comet.CometVariables.hmPattern
 import io.github.starwishsama.comet.CometVariables.mapper
 import io.github.starwishsama.comet.api.thirdparty.twitter.TwitterApi
 import io.github.starwishsama.comet.api.thirdparty.twitter.data.tweetEntity.Media


### PR DESCRIPTION
## 更改理由

1. 大多数情况下你并不关心发送时间的秒数位
2. 最后一行可以和前述时间放一起，既节省长度又使文本语义内聚性更强